### PR TITLE
Automatically move OBSE plugins to the right place.

### DIFF
--- a/src/oblivionmoddatachecker.cpp
+++ b/src/oblivionmoddatachecker.cpp
@@ -1,0 +1,30 @@
+#include "oblivionmoddatachecker.h"
+
+ModDataChecker::CheckReturn OblivionModDataChecker::dataLooksValid(
+  std::shared_ptr<const MOBase::IFileTree> fileTree) const
+{
+  // Check with Gamebryo stuff:
+  auto check = GamebryoModDataChecker::dataLooksValid(fileTree);
+  if (check == CheckReturn::VALID) {
+    return check;
+  }
+
+  // Check for OBSE_ files:
+  for (auto const& entry : *fileTree) {
+    if (entry->isDir() || !entry->name().startsWith("OBSE", Qt::CaseInsensitive)) {
+      return CheckReturn::INVALID;
+    }
+  }
+
+  return CheckReturn::FIXABLE;
+}
+
+std::shared_ptr<MOBase::IFileTree> OblivionModDataChecker::fix(
+  std::shared_ptr<MOBase::IFileTree> fileTree) const
+{
+  // If we arrive here, it means all files starts with OBSE.
+  auto data = fileTree->createOrphanTree();
+  auto obse = data->addDirectory("OBSE/Plugins");
+  obse->merge(fileTree);
+  return data;
+}

--- a/src/oblivionmoddatachecker.h
+++ b/src/oblivionmoddatachecker.h
@@ -8,6 +8,9 @@ class OblivionModDataChecker : public GamebryoModDataChecker
 public:
   using GamebryoModDataChecker::GamebryoModDataChecker;
 
+  CheckReturn dataLooksValid(std::shared_ptr<const MOBase::IFileTree> fileTree) const override;
+  std::shared_ptr<MOBase::IFileTree> fix(std::shared_ptr<MOBase::IFileTree> fileTree) const override;
+
 protected:
   virtual const FileNameSet& possibleFolderNames() const override {
     static FileNameSet result{


### PR DESCRIPTION
There are a lots of OBSE plugins on Nexus improperly packed, typically the DLL alongside the INI file at the root of the archive. This tries to automatically fix this:

- If the archive is not valid, 
- and all the files starts with `OBSE`,
- move all the `OBSE*` file to `OBSE/Plugins`.